### PR TITLE
Don't depend on simplejson from Django <1.7

### DIFF
--- a/progressbarupload/views.py
+++ b/progressbarupload/views.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from django.http import HttpResponse
-from django.utils import simplejson
 from django.core.cache import cache
+
+try:
+    import json
+except ImportError:
+    # Django <1.7 packages simplejson for older Python versions
+    from django.utils import simplejson as json
 
 
 def upload_progress(request):
@@ -17,4 +22,4 @@ def upload_progress(request):
     if progress_id:
         cache_key = "%s_%s" % (request.META['REMOTE_ADDR'], progress_id)
         data = cache.get(cache_key)
-        return HttpResponse(simplejson.dumps(data))
+        return HttpResponse(json.dumps(data))


### PR DESCRIPTION
In `views.py` there's the following import

``` python
from django.utils import simplejson
```

This fails, as [`django.utils.simplejson` has been removed](https://docs.djangoproject.com/en/dev/releases/1.7/#features-removed-in-1-7) in Django 1.7.
