### PR TITLE
Broken urls.py with python 3.5 and django 1.9

### DIFF
--- a/progressbarupload/urls.py
+++ b/progressbarupload/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import url
-from views import upload_progress
+from progressbarupload.views import upload_progress
 
 urlpatterns = [
     url(r'^upload_progress$', upload_progress, name="upload_progress"),


### PR DESCRIPTION
```
  File "/Users/sebcorbin/.virtualenvs/planexo-py3/lib/python3.5/site-packages/progressbarupload/urls.py", line 3, in <module>
    from views import upload_progress
ImportError: No module named 'views'
```