### PR TITLE
setup.py to indicate Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],


### PR DESCRIPTION
The tests already run and pass in Python 3.4, so why not indicate that this package works in Python 3 officially?
