### PR TITLE
Making the library compatible with Django 2.0. The reverse function i…

### DIFF
--- a/progressbarupload/templatetags/progress_bar.py
+++ b/progressbarupload/templatetags/progress_bar.py
@@ -4,7 +4,7 @@ from django import template
 from django.conf import settings
 from django.forms.widgets import Media
 from django.utils.safestring import mark_safe
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 register = template.Library()
 


### PR DESCRIPTION
The progress bar library do not work anymore with Django 2.0

The reverse function is moved from django.core.urlresolvers to django.urls

Can you please create a new branch called something like "compatibility-with-django-2.0" to give support for the library for Django 2.0.

Thanks :)